### PR TITLE
feat: macOS support, permission relay, existing-account reuse

### DIFF
--- a/src/setup.ts
+++ b/src/setup.ts
@@ -57,7 +57,18 @@ function checkJava(): void {
 function findSignalCli(): string | null {
   try {
     const out = execSync("signal-cli --version 2>&1", { encoding: "utf8" });
-    if (out.includes("signal-cli")) return "signal-cli";
+    if (out.includes("signal-cli")) {
+      // Resolve to an absolute path so processes spawned by Claude Code
+      // (especially under launchd, where PATH is minimal) can find the binary.
+      try {
+        const which = IS_WIN ? "where" : "which";
+        const resolved = execSync(`${which} signal-cli`, { encoding: "utf8" })
+          .trim()
+          .split("\n")[0];
+        if (resolved && existsSync(resolved)) return resolved;
+      } catch {}
+      return "signal-cli";
+    }
   } catch {}
 
   const bin = IS_WIN
@@ -133,8 +144,38 @@ async function installSignalCli(): Promise<string> {
 
 // --- Step 3: Link device (uses link.ts) ---
 
+/**
+ * Check signal-cli for any already-registered/linked accounts. Returns the
+ * list of phone numbers (e.g. "+15551234567"). Empty array on failure.
+ */
+function findExistingAccounts(signalCliPath: string): string[] {
+  try {
+    const out = execSync(`"${signalCliPath}" listAccounts 2>&1`, { encoding: "utf8" });
+    return Array.from(out.matchAll(/Number:\s*(\+\d+)/g), (m) => m[1]);
+  } catch {
+    return [];
+  }
+}
+
 async function doLinkDevice(signalCliPath: string): Promise<string> {
   step(3, "Link device");
+
+  // If signal-cli already has an account linked, offer to reuse it instead
+  // of creating a duplicate "Claude Code" entry on the user's Signal account.
+  const existing = findExistingAccounts(signalCliPath);
+  if (existing.length > 0 && !process.argv.includes("--force-link")) {
+    log(`  Found existing linked account(s): ${existing.join(", ")}`);
+    if (process.argv.includes("--yes")) {
+      ok(`Using existing account ${existing[0]} (--yes)`);
+      return existing[0];
+    }
+    const answer = await ask(`  Use ${existing[0]}? [Y/n] `);
+    if (answer.toLowerCase() !== "n") {
+      ok(`Using existing account ${existing[0]}`);
+      return existing[0];
+    }
+  }
+
   log("  Get your phone ready — a QR code will open in your browser.");
   log("  Open Signal > Settings > Linked Devices > Link New Device\n");
 

--- a/src/signal.ts
+++ b/src/signal.ts
@@ -4,11 +4,28 @@ import {
   ListToolsRequestSchema,
   CallToolRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { z } from "zod";
 import { loadConfig } from "./config.js";
 import { AccessManager } from "./access.js";
 import { SignalTcpClient, type SignalMessage } from "./tcp-client.js";
 import { DaemonManager } from "./daemon.js";
 import { mkdirSync } from "node:fs";
+
+// Permission relay: matches "yes abcde" / "no abcde" verdict replies sent
+// from the channel owner's phone. The 5-letter ID alphabet skips 'l' (per
+// the channels-reference doc) so it never reads as 1/I on a phone. /i
+// tolerates phone autocorrect capitalizing the verdict word.
+const PERMISSION_REPLY_RE = /^\s*(y|yes|n|no)\s+([a-km-z]{5})\s*$/i;
+
+const PermissionRequestSchema = z.object({
+  method: z.literal("notifications/claude/channel/permission_request"),
+  params: z.object({
+    request_id: z.string(),
+    tool_name: z.string(),
+    description: z.string(),
+    input_preview: z.string(),
+  }),
+});
 
 export function getReplyToolSchema() {
   return {
@@ -182,7 +199,13 @@ async function main() {
     { name: "signal", version: "0.1.0" },
     {
       capabilities: {
-        experimental: { "claude/channel": {} },
+        experimental: {
+          "claude/channel": {},
+          // Opt in to permission relay so Bash/Write/Edit approval prompts
+          // are forwarded to the channel owner's phone in parallel with the
+          // local terminal dialog. Only honored from own account (see below).
+          "claude/channel/permission": {},
+        },
         tools: {},
       },
       instructions: INSTRUCTIONS,
@@ -223,7 +246,42 @@ async function main() {
     };
   });
 
+  // Permission relay: when Claude wants to run a tool that needs approval,
+  // Claude Code calls this notification handler with a 5-letter request_id.
+  // We forward it to the owner's phone via Note to Self; the owner replies
+  // "yes <id>" or "no <id>" and the inbound handler below converts that to
+  // a permission verdict notification.
+  server.setNotificationHandler(PermissionRequestSchema, async ({ params }) => {
+    if (!config.signalAccount) return;
+    const text =
+      `Claude wants to run ${params.tool_name}: ${params.description}\n\n` +
+      `Reply "yes ${params.request_id}" or "no ${params.request_id}"`;
+    try {
+      await tcp.send(config.signalAccount, text, config.signalAccount);
+    } catch (err) {
+      console.error(`[signal] Failed to relay permission prompt: ${err}`);
+    }
+  });
+
   tcp.on("message", async (msg: SignalMessage) => {
+    // Permission verdict — only honored from own account (Note to Self).
+    // Anyone else's verdict-shaped reply falls through to the normal chat
+    // path and is gated/forwarded as text. This is the security anchor:
+    // only the channel owner's phone can approve tool execution.
+    if (config.signalAccount && msg.sender === config.signalAccount) {
+      const m = PERMISSION_REPLY_RE.exec(msg.text);
+      if (m) {
+        await server.notification({
+          method: "notifications/claude/channel/permission",
+          params: {
+            request_id: m[2].toLowerCase(),
+            behavior: m[1].toLowerCase().startsWith("y") ? "allow" : "deny",
+          },
+        });
+        return;
+      }
+    }
+
     await routeInboundMessage(
       access,
       msg,

--- a/src/uninstall.ts
+++ b/src/uninstall.ts
@@ -9,7 +9,7 @@
  * 5. Removes MCP config from ~/.claude.json
  */
 import { execSync } from "node:child_process";
-import { existsSync, readFileSync, writeFileSync, rmSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, rmSync, readdirSync } from "node:fs";
 import { join } from "node:path";
 import { homedir, platform } from "node:os";
 import { createInterface } from "node:readline";
@@ -95,7 +95,7 @@ async function unregisterDevice(): Promise<void> {
   try {
     const dataDir = join(SIGNAL_CLI_DIR, "data");
     if (existsSync(dataDir)) {
-      for (const entry of require("fs").readdirSync(dataDir)) {
+      for (const entry of readdirSync(dataDir)) {
         const d = join(dataDir, entry);
         if (entry.endsWith(".d") && existsSync(d)) {
           try { rmSync(join(d, "account.db-shm"), { force: true }); } catch {}


### PR DESCRIPTION
## Summary

Three commits, each independently reviewable:

1. **fix(uninstall): replace CommonJS require with ESM import** — \`uninstall.ts\` calls \`require(\"fs\").readdirSync\` inside the SQLite-lock cleanup block, but the package is ESM (\`\"type\": \"module\"\` in package.json). On any platform, the moment that branch executes it throws \`require is not defined\`; it was masked because the surrounding try/catch swallows it. Fix: import \`readdirSync\` at the top.

2. **feat(setup): absolute signal-cli path + reuse existing linked account** — two macOS-friendly improvements (both portable):
   - \`findSignalCli()\` now resolves the binary to its absolute path via \`which signal-cli\` (or \`where\` on Windows) when found on PATH. The prior behavior stored the literal string \`\"signal-cli\"\` in \`~/.claude.json\`, which fails when Claude Code's MCP subprocess doesn't inherit the user's interactive shell PATH. This is the common case under launchd LaunchAgents on macOS, where \`/opt/homebrew/bin\` isn't on the default PATH.
   - \`doLinkDevice()\` detects accounts already registered with signal-cli (via \`signal-cli listAccounts\`) and offers to reuse one. Without this, re-running setup creates a duplicate \`Claude Code\` entry on the user's Signal account, and users with an existing signal-cli installation are forced to link a new device they don't need. \`--force-link\` bypasses; \`--yes\` accepts the default.

3. **feat(channel): implement permission relay for tool approvals** — declares the \`claude/channel/permission\` capability and wires up both halves of the loop documented in the [channels reference](https://code.claude.com/docs/en/channels-reference):
   - **Outbound:** a \`setNotificationHandler\` for \`permission_request\` that formats the prompt (tool name, description, 5-letter \`request_id\`) and sends it via Note to Self.
   - **Inbound:** a verdict-detection branch in the existing \`tcp.on(\"message\")\` handler. Matches \`yes <id>\` / \`no <id>\` (case-insensitive, \`/[a-km-z]{5}/\` to match Claude Code's no-'l' alphabet) and emits \`notifications/claude/channel/permission\`. Verdicts are only honored when \`sender === SIGNAL_ACCOUNT\` — the channel owner's phone is the security anchor, so allowlisted-but-not-owner senders cannot approve tool execution. Their verdict-shaped messages fall through to the normal chat path.

   The local terminal dialog stays open in parallel; whichever answer arrives first is applied.

## Testing

Verified end-to-end on Apple Silicon macOS 14+ (Mac mini M2):

- All 48 existing tests pass against the patches (\`npm test\`).
- Pre-existing TypeScript errors in \`tcp-client.ts:113\` and \`test/signal.test.ts\` are present on \`main\` too — not introduced by this PR (\`tsc --noEmit\` is dirty before and after).
- \`npm run setup -- --yes\` against an existing \`signal-cli\` (Homebrew, \`/opt/homebrew/bin/signal-cli\`) with a pre-linked account: detects the account, skips re-linking, writes absolute path to \`~/.claude.json\`, completes cleanly.
- Note-to-Self round-trip: message → channel notification → Claude reply → Signal: works.
- Permission relay round-trip: privileged \`Write\` to a path outside the workspace → notification with \`request_id\` arrives via Note to Self → reply \`yes <id>\` → tool executes → Claude confirms back. Verified the verdict only honors own-account replies.

## Compatibility

- All three commits are backward-compatible: existing Windows users, fresh installs, and re-runs of \`npm run setup\` continue to work as before.
- Permission relay declares a new capability; older Claude Code (pre-2.1.81) silently ignores it per the channels reference.
- The \`--force-link\` and \`--yes\` flags are additive opt-ins.

This was tested on macOS as the README invited (\"This has only been tested on Windows. If you're on macOS or Linux, testing and PRs with fixes are very welcome\"). Happy to split this into separate PRs if you'd prefer to review the permission-relay change independently of the macOS-compatibility commits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)